### PR TITLE
Add timestamp for the remote Jupyter server info

### DIFF
--- a/docs/jupyter/remote_browser.md
+++ b/docs/jupyter/remote_browser.md
@@ -13,7 +13,7 @@ To avoid the issue with your browser loosing connection you can run the browser 
 
 ## fast.ai
 
-The below youtube link, from fastai Lesson 10 Part 2 (2018) will walk you through how to accomplish this.
+The below youtube link (at timestamp 1:59:00), from fastai Lesson 10 Part 2 (2018) will walk you through how to accomplish this.
 
-{% include youtube.html content="h5Tz7gZT9Fo" %}
+{% include youtube.html content="h5Tz7gZT9Fo?t=7140" %}
 


### PR DESCRIPTION
I had to skim through the entire video before. I thought I would just add the timestamp info for you. I added it to the embed like how you would do with a typical YouTube video but I am not sure if it necessarily works.